### PR TITLE
Require at least one digit in release

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	versionRegexp = matchingRegexp{regexp.MustCompile(`\A(?P<release>[0-9A-Za-z_\.]+)(\-(?P<pre_release>[0-9A-Za-z_\-\.]+))?(\+(?P<post_release>[0-9A-Za-z_\-\.]+))?\z`)}
+	versionRegexp = matchingRegexp{regexp.MustCompile(`\A(?P<release>[0-9A-Za-z_\.]*[0-9_\.]+[0-9A-Za-z_\.]*)(\-(?P<pre_release>[0-9A-Za-z_\-\.]+))?(\+(?P<post_release>[0-9A-Za-z_\-\.]+))?\z`)}
 )
 
 type matchingRegexp struct {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -70,6 +70,11 @@ var _ = Describe("NewVersionFromString", func() {
 		_, err = NewVersionFromString("can\"t do it cap\"n")
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("raises an ArgumentError if no digit in release segments", func() {
+		_, err := NewVersionFromString("alpha-1")
+		Expect(err).To(HaveOccurred())
+	})
 })
 
 var _ = Describe("Version", func() {


### PR DESCRIPTION
This pull request makes it so versions without a single digit in their release segment are no longer valid.
